### PR TITLE
Cherry-pick bartoszkopinski's Rails 4.1.0+ syntax fix onto gem version 0.6.3

### DIFF
--- a/lib/aws/s3/extensions.rb
+++ b/lib/aws/s3/extensions.rb
@@ -258,7 +258,7 @@ class Class # :nodoc:
     cattr_reader(*syms)
     cattr_writer(*syms)
   end
-end if Class.instance_methods(false).grep(/^cattr_(?:reader|writer|accessor)$/).empty?
+end if Class.instance_methods.grep(/^cattr_(?:reader|writer|accessor)$/).empty?
 
 module SelectiveAttributeProxy
   def self.included(klass)


### PR DESCRIPTION
The `aws-s3` gem is unmaintained and we should ideally switch to `aws-sdk` (see discussion in https://github.com/marcel/aws-s3/pull/95). In the short term, however, we can mitigate any risk by forking `marcel/aws-s3`, rewinding the HEAD to the commit corresponding to rubygem version `0.6.3` (previously in the `Gemfile.lock` for the app store, since no version was specified in the `Gemfile`), and then spot-applying the one-line fix from the PR referenced above.

The reason we need to rewind the HEAD is that no official gem release occurred after May 29, 2012 (commit 0572f4b) even though several PRs were merged onto `marcel/aws-s3`'s master branch.

- [x] Fork marcel/aws-s3
- [x] rewind HEAD to commit corresponding to rubygem version 0.6.3 (0572f4b)
- [x] manually apply Rails 4.1.0+ syntax fix from https://github.com/marcel/aws-s3/pull/95